### PR TITLE
added tests for JSON support

### DIFF
--- a/postgres-tests.js
+++ b/postgres-tests.js
@@ -142,4 +142,30 @@ describe('LIMIT ... OFFSET', function() {
   });
 });
 
+describe('JSON', function() {
+  describe('Objects', function() {
+    it('should handle UPDATE', function() {
+      assert.equal(update('user').set({'address': { state: "CA" }}).where({'lname': 'Flintstone'}).toString(),
+        "UPDATE \"user\" SET address = '{\"state\":\"CA\"}' WHERE lname = 'Flintstone'");
+    });
+
+    it('should handle INSERT', function() {
+      assert.equal(insert('user').values({'address': { state: "CA" }}).toString(),
+        "INSERT INTO \"user\" (address) VALUES ('{\"state\":\"CA\"}')");
+    });
+  });
+
+  describe('Arrays', function() {
+    it('should handle UPDATE', function() {
+      assert.equal(update('user').set({'numbers': [42, 84]}).where({'lname': 'Flintstone'}).toString(),
+        "UPDATE \"user\" SET numbers = '[42,84]' WHERE lname = 'Flintstone'");
+    });
+
+    it('should handle INSERT', function() {
+      assert.equal(insert('user').values({'numbers': [42, 84]}).toString(),
+        "INSERT INTO \"user\" (numbers) VALUES ('[42,84]')");
+    });
+  });
+});
+
 })();


### PR DESCRIPTION
Any thoughts on supporting the [JSON type](http://www.postgresql.org/docs/9.3/static/datatype-json.html) in the  insert and update clauses? Currently `sql-bricks` throws an error for objects:

    insert('user').values({'address': { state: "CA" }}).toString()

    > ERROR: value is of an unsupported type and cannot be converted to SQL: [object Object]

Supporting arrays might be trickier since postgres also has [arrays](http://www.postgresql.org/docs/9.3/static/arrays.html):

    insert('user').values({'number': [42, 84]}).toString()

    //currently
    INSERT INTO "user" (numbers) VALUES ({42, 84})

    //JSON version
    INSERT INTO "user" (numbers) VALUES ('[42,84]')

This pull request just includes breaking tests. Right now, I'm serializing array or object columns first. ie:

    var copy = _.clone(row); //shallow copy
    _.each(copy, function(val, key){
      if (_.isArray(val) || _.isPlainObject(val)) {
        copy[key] = JSON.stringify(val);
      }
    });