### PR TITLE
fix(convert): play nicely with pg supported types

### DIFF
--- a/postgres.js
+++ b/postgres.js
@@ -172,6 +172,10 @@
   //       see https://github.com/CSNW/sql-bricks/issues/62
   var _convert = sql.convert;
   sql.convert = function (val) {
+    // support pg types if available. this handles types like interval.
+    if (val && typeof val.toPostgres === 'function') {
+        val = val.toPostgres();
+    }
     if (_.isObject(val) && !_.isArray(val) && !_.isArguments(val))
       return _convert(JSON.stringify(val));
 

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,10 @@ sql.select("text").from("example").where(sql.ilike("text", "%EASY%PEASY%"))
 // SELECT text FROM example WHERE text ILIKE '%EASY%PEASY%'
 ```
 
+## PostgreSQL Type Compatability
+Supports [node-postgres](https://github.com/brianc/node-postgres) `toPostgres()` conventions to format Javascript appropriately for PostgreSQL.
+See [postgres-interval](https://github.com/bendrucker/postgres-interval) for an example of this pattern in action. ([index.js#L14-L22](https://github.com/bendrucker/postgres-interval/blob/master/index.js#L14-L22))
+
 
 ## Even Harder Things
 


### PR DESCRIPTION
This fixes issues around types (such as `interval`) if using the `pg` module.