### PR TITLE
Update to sql-bricks 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": "*"
   },
   "dependencies": {
-    "sql-bricks": "git+https://github.com/CSNW/sql-bricks.git#v3.0.0-beta.4",
+    "sql-bricks": "^3",
     "underscore": "^1.4.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": "*"
   },
   "dependencies": {
-    "sql-bricks": "^2",
+    "sql-bricks": "git+https://github.com/CSNW/sql-bricks.git#v3.0.0-beta.4",
     "underscore": "^1.4.x"
   },
   "devDependencies": {


### PR DESCRIPTION
@Suor: This pull request updates sql-bricks-postgres to use the newly-published sql-bricks 3.0. The main advantage of 3.0 is that it removes the underscore dependency (it was depending on an old version that had security vulnerabilities).

v3.0 is much less ambitious than [originally planned](https://github.com/CSNW/sql-bricks/issues/92). The main thing done (besides the removal of Underscore) is the removal of the mini-templating language, in favor of Javascript's built-in template literals. This required some changes to sql-bricks-postgres (included in this pull request).

I got the sql-bricks-postgres tests all passing and I have one project that depends on it and verified that its tests are all passing. That said, if you have any projects that depend on sql-bricks-postgres, it'd be comforting to know that their tests pass with these changes before publishing this to npm (perhaps as version `1.0.0` or `0.6.0`?)