### PR TITLE
Add ability to use SQL functions or operators in the `DO UPDATE` clause

### DIFF
--- a/postgres-tests.js
+++ b/postgres-tests.js
@@ -177,6 +177,12 @@ describe('Postgres extension for SQLBricks', function() {
         "INSERT INTO \"user\" (name) VALUES ('Alex') ON CONFLICT DO UPDATE SET name = EXCLUDED.name")
     })
 
+    it('should make upsert with SQL function', function() {
+      assert.equal(insert('user', {name: 'Alex'})
+      .onConflict().doUpdate().set(sql('name = coalesce(EXCLUDED.name, $1)', "Alex")).toString(),
+        "INSERT INTO \"user\" (name) VALUES ('Alex') ON CONFLICT DO UPDATE SET name = coalesce(EXCLUDED.name, 'Alex')")
+    })
+
     it('should filter update', function() {
       assert.equal(insert('user', {name: 'Alex'}).onConflict().doUpdate().where(sql('is_active')).toString(),
         "INSERT INTO \"user\" (name) VALUES ('Alex') ON CONFLICT DO UPDATE SET name = EXCLUDED.name WHERE is_active")

--- a/postgres.js
+++ b/postgres.js
@@ -138,7 +138,7 @@
     {after: 'onConflict'});
   Insert.defineClause(
     'doUpdateSet',
-    '{{#if _doUpdateSet}}DO UPDATE SET {{expression _doUpdateSet}}{{/if}}',
+    function (opts) { if (this._doUpdateSet) return `DO UPDATE SET ${sql._handleExpression(this._doUpdateSet, opts)}`; },
     {after: 'onConstraint'}
   );
   Insert.defineClause('doNothing', function(opts) { if (this._doNothing) return `DO NOTHING`; }, {after: 'onConstraint'});

--- a/postgres.js
+++ b/postgres.js
@@ -121,6 +121,9 @@
     this.where = this.and = function () {
       return this._addExpression(arguments, '_doUpdateWhere');
     }
+    this.set = this.and = function() {
+      return this._addExpression(arguments, '_doUpdateSet');
+    }
     return this;
   }
 
@@ -133,8 +136,14 @@
   );
   Insert.defineClause('onConstraint', function(opts) { if (this._onConstraint) return `ON CONSTRAINT ${this._onConstraint}`; },
     {after: 'onConflict'});
+  Insert.defineClause(
+    'doUpdateSet',
+    '{{#if _doUpdateSet}}DO UPDATE SET {{expression _doUpdateSet}}{{/if}}',
+    {after: 'onConstraint'}
+  );
   Insert.defineClause('doNothing', function(opts) { if (this._doNothing) return `DO NOTHING`; }, {after: 'onConstraint'});
   Insert.defineClause('doUpdate', function(opts) {
+      if(this._doUpdateSet) return;
       if(!this._doUpdate) return;
 
       var columns = this._doUpdate;
@@ -144,7 +153,7 @@
         var col = sql._handleColumn(col, opts);
         return col + ' = EXCLUDED.' + col;
       }).join(', ');
-    }, {after: 'onConstraint'}
+    }, {after: 'doUpdateSet'}
   );
   Insert.defineClause(
     'doUpdateWhere',

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,14 @@ sql.insert('user', {name: 'Alex', age: 34})
 // INSERT INTO "user" (name) VALUES ('Alex', 34)
 //   ON CONFLICT (name)
 //   DO UPDATE SET name = EXCLUDED.name, age = EXCLUDED.age
+
+// manipulate the data in the `DO UPDATE`:
+sql.insert('user', {name: 'Alex', age: 34})
+    .onConflict('name').doUpdate()
+    .set(sql('name = coalesce(EXCLUDED.name, $1), age = $2 + 10', t1, t2))
+// INSERT INTO "user" (name) VALUES ('Alex', 34)
+//   ON CONFLICT (name)
+//   DO UPDATE SET name = coalesce(EXCLUDED.name, $3), age = $4 + 10
 ```
 
 Other clauses such as `DO NOTHING`, `ON CONSTRAINT` and `WHERE` are


### PR DESCRIPTION
This adds functionality to allow manipulation of the data fields in the `DO UPDATE`. This allows cases where you wish to do something with the existing data rather than just overwrite it with the newer values. For example you could only update the value if the field was null, or you could concatenate the new value with the old value.

`DO UPDATE SET name = coalesce(EXCLUDED.name, $3), age = $4 + 10`
`DO UPDATE SET name = EXCLUDED.name || ',' || $3, age = $4 + 10` 

If this does get merged, is there any chance of getting an updated version published to npm with this and the update to `sql-bricks` 3.0?? :pray: 

